### PR TITLE
Fix another celery task import.

### DIFF
--- a/tidings/events.py
+++ b/tidings/events.py
@@ -8,7 +8,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.db.models import Q
 
-from celery.decorators import task
+from celery.task import task
 
 from tidings.models import Watch, WatchFilter, EmailUser, multi_raw
 from tidings.utils import collate, hash_to_unsigned


### PR DESCRIPTION
Sorry, I missed this one in my last fix :-/...

```
[rlr (another-celery-task-import) django-tidings]$ workon tidings
(tidings)[rlr (another-celery-task-import) django-tidings]$ fab test
[localhost] local: test_app/manage.py test tidings
/Users/rlr/.virtualenvs/tidings/lib/python2.6/site-packages/django/conf/__init__.py:110: DeprecationWarning: The SECRET_KEY setting must not be empty.
  warnings.warn("The SECRET_KEY setting must not be empty.", DeprecationWarning)
nosetests --verbosity 1 tidings
Creating test database for alias 'default'...
........................................../Users/rlr/.virtualenvs/tidings/lib/python2.6/site-packages/jingo/__init__.py:74: DeprecationWarning: jingo.render() has been deprecated.  Use django.shortcuts.render().
  'django.shortcuts.render().', DeprecationWarning)
.......
----------------------------------------------------------------------
Ran 49 tests in 1.057s

OK
Destroying test database for alias 'default'...

Done.
```
