### PR TITLE
Remove rate limit on claim_watches task.

### DIFF
--- a/tidings/tasks.py
+++ b/tidings/tasks.py
@@ -3,7 +3,7 @@ from celery.task import task
 from tidings.models import Watch
 
 
-@task(rate_limit='1/m')
+@task()
 def claim_watches(user):
     """Attach any anonymous watches having a user's email to that user.
 


### PR DESCRIPTION
It hurts more than it helps in SUMO.

We don't really call this task frequently enough. It only comes into play when our queue gets backed up for other reasons and then it takes forever to flush these tasks out of the system.
