### PR TITLE
Add Python 3 support, fix Django 1.8 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,19 @@
-*.pyc
-.python-version
-.tox
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
 build/
 dist/
-django_tidings.egg-info/
-docs/_build
+*.egg-info/
+
+# pyenv
+.python-version
+
+# Sphinx documentation
+docs/_build/
+
+# Unit test / coverage reports
+.tox
 test.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+*.pyc
+.python-version
+.tox
+build/
+dist/
+django_tidings.egg-info/
 docs/_build
 test.db
-.tox
-django_tidings.egg-info/
-dist/
-build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ matrix:
     - python: "3.6"
       env: TOXENV=py36-master
   allow_failures:
-    - env: TOXENV=py33-1.6
-    - env: TOXENV=py34-1.7
     - env: TOXENV=py27-1.8
     - env: TOXENV=py35-1.8
     - env: TOXENV=py27-1.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ matrix:
     - python: "3.6"
       env: TOXENV=py36-master
   allow_failures:
-    - env: TOXENV=py27-1.8
-    - env: TOXENV=py35-1.8
     - env: TOXENV=py27-1.9
     - env: TOXENV=py35-1.9
     - env: TOXENV=py27-1.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,50 @@
 sudo: no
 language: python
-env:
-  matrix:
-    - TOXENV=docs
-    - TOXENV=py27-1.6
-    - TOXENV=py27-1.7
-  global:
-    - PIP_WHEEL_DIR=$HOME/.wheels
-    - PIP_FIND_LINKS=file://$PIP_WHEEL_DIR
-cache:
-  directories:
-    - $PIP_WHEEL_DIR
+cache: pip
+matrix:
+  include:
+    - python: "2.7"
+      env: TOXENV=docs
+    - python: "2.7"
+      env: TOXENV=py27-1.6
+    - python: "3.3"
+      env: TOXENV=py33-1.6
+    - python: "2.7"
+      env: TOXENV=py27-1.7
+    - python: "3.4"
+      env: TOXENV=py34-1.7
+    - python: "2.7"
+      env: TOXENV=py27-1.8
+    - python: "3.5"
+      env: TOXENV=py35-1.8
+    - python: "2.7"
+      env: TOXENV=py27-1.9
+    - python: "3.5"
+      env: TOXENV=py35-1.9
+    - python: "2.7"
+      env: TOXENV=py27-1.10
+    - python: "3.5"
+      env: TOXENV=py35-1.10
+    - python: "2.7"
+      env: TOXENV=py27-1.11
+    - python: "3.6"
+      env: TOXENV=py36-1.11
+    - python: "3.6"
+      env: TOXENV=py36-master
+  allow_failures:
+    - env: TOXENV=py33-1.6
+    - env: TOXENV=py34-1.7
+    - env: TOXENV=py27-1.8
+    - env: TOXENV=py35-1.8
+    - env: TOXENV=py27-1.9
+    - env: TOXENV=py35-1.9
+    - env: TOXENV=py27-1.10
+    - env: TOXENV=py35-1.10
+    - env: TOXENV=py27-1.11
+    - env: TOXENV=py36-1.11
+    - env: TOXENV=py36-master
 install:
-    - mkdir -p $PIP_WHEEL_DIR
-    - pip wheel -r tests/requirements.txt coveralls
-    - pip install coveralls tox
+  - pip install coveralls tox
 script:
   - tox
 after_success: coveralls

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
--r ../tests/requirements.txt
+-r ../tests/requirements-1.7.txt
 
 Sphinx==1.3.1
 Django<=1.8

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,8 +1,9 @@
 import random
-from string import letters
+from string import ascii_letters
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase  # noqa
+from django.utils.six.moves import range
 
 try:
     from django.test import override_settings  # noqa
@@ -16,8 +17,8 @@ def user(save=False, **kwargs):
     defaults = {'password':
                     'sha1$d0fcb$661bd5197214051ed4de6da4ecdabe17f5549c7c'}
     if 'username' not in kwargs:
-        defaults['username'] = ''.join(random.choice(letters)
-                                       for x in xrange(15))
+        defaults['username'] = ''.join(random.choice(ascii_letters)
+                                       for x in range(15))
     defaults.update(kwargs)
     u = get_user_model()(**defaults)
     if save:

--- a/tests/base.py
+++ b/tests/base.py
@@ -28,7 +28,7 @@ def user(save=False, **kwargs):
 
 def watch(save=False, **kwargs):
     # TODO: better defaults, when there are events available.
-    defaults = {'user': kwargs.get('user') or user(),
+    defaults = {'user': kwargs.get('user') or user(save=True),
                 'is_active': True,
                 'secret': 'abcdefghjk'}
     defaults.update(kwargs)
@@ -39,7 +39,7 @@ def watch(save=False, **kwargs):
 
 
 def watch_filter(save=False, **kwargs):
-    defaults = {'watch': kwargs.get('watch') or watch(),
+    defaults = {'watch': kwargs.get('watch') or watch(save=True),
                 'name': 'test',
                 'value': 1234}
     defaults.update(kwargs)

--- a/tests/requirements-1.7.txt
+++ b/tests/requirements-1.7.txt
@@ -1,3 +1,4 @@
+# Requirements for Django 1.7 and earlier
 jingo==0.7
 celery==3.1.18
 django-celery==3.1.16

--- a/tests/requirements-1.8.txt
+++ b/tests/requirements-1.8.txt
@@ -1,0 +1,4 @@
+# Requirements for Django 1.8
+jingo==0.9.0
+celery==3.1.18
+django-celery==3.2.1

--- a/tests/requirements-latest.txt
+++ b/tests/requirements-latest.txt
@@ -1,0 +1,4 @@
+# Latest versions of requirements
+jingo
+celery
+django-celery

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.core.mail import EmailMessage
+from django.utils.six.moves import range
 
 from tidings.events import Event, _unique_by_email, EventUnion, InstanceEvent
 from tidings.models import Watch, EmailUser
@@ -140,7 +141,7 @@ class UsersWatchingTests(TestCase):
         """When removing duplicates, make sure registered users are kept in
         favor of anonymous ones having the same email address."""
         def make_anonymous_watches():
-            for x in xrange(3):
+            for x in range(3):
                 watch(event_type=TYPE, email='hi@there.com').save()
 
         # Throw some anonymous watches in there in the hope that they would

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -47,7 +47,7 @@ class UsersWatchingTests(TestCase):
     def _emails_eq(self, addresses, event, **filters):
         """Assert that the given emails are the ones watching `event`, given
         the scoping in `filters`."""
-        self.assertEquals(sorted(addresses),
+        self.assertEqual(sorted(addresses),
                           sorted([u.email for u, w in
                                   event._users_watching_by_filter(**filters)]))
 
@@ -120,7 +120,7 @@ class UsersWatchingTests(TestCase):
               save=True)
         watch(event_type=TYPE, email='hi@there.com').save()
         watch(event_type=TYPE, email='hi@there.com').save()
-        self.assertEquals(3, Watch.objects.all().count())  # We created what we meant to.
+        self.assertEqual(3, Watch.objects.all().count())  # We created what we meant to.
 
         self._emails_eq(['hi@there.com'], SimpleEvent())
 
@@ -130,12 +130,12 @@ class UsersWatchingTests(TestCase):
               save=True)
         watch(event_type=TYPE, email='hi@EXAMPLE.com').save()
         watch(event_type=TYPE, email='hi@EXAMPLE.com').save()
-        self.assertEquals(3, Watch.objects.all().count())  # We created what we meant to.
+        self.assertEqual(3, Watch.objects.all().count())  # We created what we meant to.
 
         addresses = [u.email
                      for u, w in SimpleEvent()._users_watching_by_filter()]
-        self.assertEquals(1, len(addresses))
-        self.assertEquals('hi@example.com', addresses[0].lower())
+        self.assertEqual(1, len(addresses))
+        self.assertEqual('hi@example.com', addresses[0].lower())
 
     def test_registered_users_favored(self):
         """When removing duplicates, make sure registered users are kept in
@@ -160,7 +160,7 @@ class UsersWatchingTests(TestCase):
 
         users_and_watches = list(SimpleEvent()._users_watching_by_filter())
         u, w = users_and_watches[0]
-        self.assertEquals('Jed', u.first_name)
+        self.assertEqual('Jed', u.first_name)
 
     def test_unique_by_email_user_selection(self):
         """Test the routine that sorts through users and watches having the
@@ -184,11 +184,11 @@ class UsersWatchingTests(TestCase):
             (user(), [watch(email='none')])]
 
         favorites = list(_unique_by_email(users_and_watches))
-        self.assertEquals(4, len(favorites))
+        self.assertEqual(4, len(favorites))
 
         # Test that we chose the correct users, where there are distinguishable
         # (registered) users to choose from:
-        self.assertEquals(['a'] * 3, [u.first_name for u, w in favorites[:3]])
+        self.assertEqual(['a'] * 3, [u.first_name for u, w in favorites[:3]])
 
     def test_unique_by_email_watch_collection(self):
         """Make sure _unique_by_email() collects all watches in each cluster."""
@@ -205,11 +205,11 @@ class UsersWatchingTests(TestCase):
         result = list(_unique_by_email(users_and_watches))
 
         _, watches = result[0]
-        self.assertEquals(set([w1, w2, w3]), set(watches))
+        self.assertEqual(set([w1, w2, w3]), set(watches))
 
         # Make sure the watches accumulator gets cleared between clusters:
         _, watches = result[1]
-        self.assertEquals(set([w4, w5, w6]), set(watches))
+        self.assertEqual(set([w4, w5, w6]), set(watches))
 
     def test_unsaved_exclude(self):
         """Excluding an unsaved user should throw a ValueError."""
@@ -223,7 +223,7 @@ class EventUnionTests(TestCase):
 
     def _emails_eq(self, addresses, event):
         """Assert that the given emails are the ones watching `event`."""
-        self.assertEquals(sorted(addresses),
+        self.assertEqual(sorted(addresses),
                           sorted([u.email for u, w in
                                   event._users_watching()]))
 
@@ -254,8 +254,8 @@ class EventUnionTests(TestCase):
                      EventUnion(OneEvent(),
                                 AnotherEvent())._users_watching()]
 
-        self.assertEquals(2, len(addresses))
-        self.assertEquals('he@llo.com', addresses[0].lower())
+        self.assertEqual(2, len(addresses))
+        self.assertEqual('he@llo.com', addresses[0].lower())
 
     def test_fire(self):
         """Assert firing the union gets the mails from the first event."""
@@ -278,7 +278,7 @@ class EventUnionTests(TestCase):
         w1 = watch(event_type=TYPE, email='jeff@here.com', save=True)
         w2 = watch(event_type=TYPE, email='jeff@here.com', save=True)
         u, w = list(EventUnion(SimpleEvent())._users_watching())[0]
-        self.assertEquals([w1, w2], sorted(w, key=lambda x: x.id))
+        self.assertEqual([w1, w2], sorted(w, key=lambda x: x.id))
 
 
 class NotificationTests(TestCase):
@@ -302,8 +302,8 @@ class NotificationTests(TestCase):
         """Assure notify() returns an existing watch when possible."""
         u = user(save=True)
         w = FilteredContentTypeEvent.notify(u, color=3, flavor=4)
-        self.assertEquals(w.pk, FilteredContentTypeEvent.notify(u, color=3, flavor=4).pk)
-        self.assertEquals(1, Watch.objects.all().count())
+        self.assertEqual(w.pk, FilteredContentTypeEvent.notify(u, color=3, flavor=4).pk)
+        self.assertEqual(1, Watch.objects.all().count())
 
     def test_duplicate_tolerance(self):
         """Assure notify() returns an existing watch if there is a matching
@@ -373,30 +373,30 @@ class MailTests(TestCase):
         SimpleEvent.notify('hi@there.com').activate().save()
         SimpleEvent().fire()
 
-        self.assertEquals(1, len(mail.outbox))
+        self.assertEqual(1, len(mail.outbox))
         first_mail = mail.outbox[0]
-        self.assertEquals(['hi@there.com'], first_mail.to)
-        self.assertEquals('Subject!', first_mail.subject)
-        self.assertEquals('Body!', first_mail.body)
+        self.assertEqual(['hi@there.com'], first_mail.to)
+        self.assertEqual('Subject!', first_mail.subject)
+        self.assertEqual('Body!', first_mail.body)
 
     def test_anonymous_notify_and_fire(self):
         """Calling notify() sends confirmation email, and calling fire() sends
         notification email."""
         w = SimpleEvent.notify('hi@there.com')
 
-        self.assertEquals(1, len(mail.outbox))
+        self.assertEqual(1, len(mail.outbox))
         first_mail = mail.outbox[0]
-        self.assertEquals(['hi@there.com'], first_mail.to)
-        self.assertEquals('TODO', first_mail.subject)
-        self.assertEquals('Activate!', first_mail.body)
+        self.assertEqual(['hi@there.com'], first_mail.to)
+        self.assertEqual('TODO', first_mail.subject)
+        self.assertEqual('Activate!', first_mail.body)
 
         w.activate().save()
         SimpleEvent().fire()
 
         second_mail = mail.outbox[1]
-        self.assertEquals(['hi@there.com'], second_mail.to)
-        self.assertEquals('Subject!', second_mail.subject)
-        self.assertEquals('Body!', second_mail.body)
+        self.assertEqual(['hi@there.com'], second_mail.to)
+        self.assertEqual('Subject!', second_mail.subject)
+        self.assertEqual('Body!', second_mail.body)
 
     @override_settings(TIDINGS_CONFIRM_ANONYMOUS_WATCHES=False)
     def test_exclude(self):
@@ -407,10 +407,10 @@ class MailTests(TestCase):
 
         SimpleEvent().fire(exclude=registered_user)
 
-        self.assertEquals(1, len(mail.outbox))
+        self.assertEqual(1, len(mail.outbox))
         first_mail = mail.outbox[0]
-        self.assertEquals(['du@de.com'], first_mail.to)
-        self.assertEquals('Subject!', first_mail.subject)
+        self.assertEqual(['du@de.com'], first_mail.to)
+        self.assertEqual('Subject!', first_mail.subject)
 
     @override_settings(TIDINGS_CONFIRM_ANONYMOUS_WATCHES=False)
     def test_exclude_multiple(self):
@@ -423,8 +423,8 @@ class MailTests(TestCase):
 
         SimpleEvent().fire(exclude=[user1, user2])
 
-        self.assertEquals(1, len(mail.outbox))
-        self.assertEquals(['du@de.com'], mail.outbox[0].to)
+        self.assertEqual(1, len(mail.outbox))
+        self.assertEqual(['du@de.com'], mail.outbox[0].to)
 
 
 def test_anonymous_user_compares():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,7 +30,7 @@ class WatchFilterTests(TestCase):
         """
         MAX_INT = 2 ** 32 - 1
         watch_filter(name='maxint', value=MAX_INT).save()
-        self.assertEquals(MAX_INT, WatchFilter.objects.get(name='maxint').value)
+        self.assertEqual(MAX_INT, WatchFilter.objects.get(name='maxint').value)
 
 
 class EmailUserTests(TestCase):
@@ -44,4 +44,4 @@ class EmailUserTests(TestCase):
         on it.
 
         """
-        self.assertEquals('', EmailUser().username)
+        self.assertEqual('', EmailUser().username)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -24,8 +24,8 @@ class ClaimWatchesTests(TestCase):
 
         # Original anonymous watch is claimed.
         assert not Watch.objects.filter(email='some@bo.dy').exists()
-        self.assertEquals(2, Watch.objects.filter(email=None).count())
-        self.assertEquals(2, Watch.objects.filter(user=u).count())
+        self.assertEqual(2, Watch.objects.filter(email=None).count())
+        self.assertEqual(2, Watch.objects.filter(user=u).count())
 
         # No other watches are affected.
         assert Watch.objects.filter(email='no@bo.dy').exists()
@@ -47,7 +47,7 @@ class ClaimWatchesTests(TestCase):
 
         # Original anonymous watch is claimed.
         assert not Watch.objects.filter(email='some@bo.dy').exists()
-        self.assertEquals(2, Watch.objects.filter(email=None).count())
+        self.assertEqual(2, Watch.objects.filter(email=None).count())
 
         # No other watches are affected.
         assert Watch.objects.filter(email='no@bo.dy').exists()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -45,4 +45,4 @@ class UnsubscribeTests(TestCase):
         response = self.client.post(
             reverse('tidings.unsubscribe', args=[w.pk]) + '?s=' + w.secret)
         self.assertContains(response, '<h1>Unsubscribed</h1>')
-        self.assertEquals(0, Watch.objects.count())
+        self.assertEqual(0, Watch.objects.count())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,30 +14,30 @@ class MergeTests(TestCase):
     def test_default(self):
         """Test with the default `key` function."""
         iterables = [range(4), range(7), range(3, 6)]
-        self.assertEquals(sorted(reduce(list.__add__,
+        self.assertEqual(sorted(reduce(list.__add__,
                                         [list(it) for it in iterables])),
                           list(collate(*iterables)))
 
     def test_key(self):
         """Test using a custom `key` function."""
         iterables = [range(5, 0, -1), range(4, 0, -1)]
-        self.assertEquals(list(sorted(reduce(list.__add__,
+        self.assertEqual(list(sorted(reduce(list.__add__,
                                              [list(it) for it in iterables]),
                                       reverse=True)),
                           list(collate(*iterables, key=lambda x: -x)))
 
     def test_empty(self):
         """Be nice if passed an empty list of iterables."""
-        self.assertEquals([], list(collate()))
+        self.assertEqual([], list(collate()))
 
     def test_one(self):
         """Work when only 1 iterable is passed."""
-        self.assertEquals([0, 1], list(collate(range(2))))
+        self.assertEqual([0, 1], list(collate(range(2))))
 
     def test_reverse(self):
         """Test the `reverse` kwarg."""
         iterables = [range(4, 0, -1), range(7, 0, -1), range(3, 6, -1)]
-        self.assertEquals(sorted(reduce(list.__add__,
+        self.assertEqual(sorted(reduce(list.__add__,
                                         [list(it) for it in iterables]),
                                  reverse=True),
                           list(collate(*iterables, reverse=True)))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,6 @@ from .base import TestCase, override_settings
 
 class MergeTests(TestCase):
     """Unit tests for collate()"""
-    # Also accidentally tests peekable, though that could use its own tests
 
     def test_default(self):
         """Test with the default `key` function."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.six.moves import range, reduce
 
 from tidings.utils import collate, import_from_setting
 
@@ -12,14 +13,14 @@ class MergeTests(TestCase):
 
     def test_default(self):
         """Test with the default `key` function."""
-        iterables = [xrange(4), xrange(7), xrange(3, 6)]
+        iterables = [range(4), range(7), range(3, 6)]
         self.assertEquals(sorted(reduce(list.__add__,
                                         [list(it) for it in iterables])),
                           list(collate(*iterables)))
 
     def test_key(self):
         """Test using a custom `key` function."""
-        iterables = [xrange(5, 0, -1), xrange(4, 0, -1)]
+        iterables = [range(5, 0, -1), range(4, 0, -1)]
         self.assertEquals(list(sorted(reduce(list.__add__,
                                              [list(it) for it in iterables]),
                                       reverse=True)),
@@ -31,11 +32,11 @@ class MergeTests(TestCase):
 
     def test_one(self):
         """Work when only 1 iterable is passed."""
-        self.assertEquals([0, 1], list(collate(xrange(2))))
+        self.assertEquals([0, 1], list(collate(range(2))))
 
     def test_reverse(self):
         """Test the `reverse` kwarg."""
-        iterables = [xrange(4, 0, -1), xrange(7, 0, -1), xrange(3, 6, -1)]
+        iterables = [range(4, 0, -1), range(7, 0, -1), range(3, 6, -1)]
         self.assertEquals(sorted(reduce(list.__add__,
                                         [list(it) for it in iterables]),
                                  reverse=True),

--- a/tidings/models.py
+++ b/tidings/models.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.db import models, connections, router
+from django.utils.six import next
 
 try:
     from django.contrib.contenttypes.fields import (GenericForeignKey,
@@ -33,8 +34,8 @@ def multi_raw(query, params, models, model_to_fields):
     rows = cursor.fetchall()
 
     for row in rows:
-        next_value = iter(row).next
-        yield [model_class(**dict((a, next_value())
+        row_iter = iter(row)
+        yield [model_class(**dict((a, next(row_iter))
                            for a in model_to_fields[model_class]))
                for model_class in models]
 

--- a/tidings/utils.py
+++ b/tidings/utils.py
@@ -12,44 +12,6 @@ except ImportError:
     from importlib import import_module
 
 
-class peekable(object):
-    """Wrapper for an iterator to allow 1-item lookahead"""
-    # Lowercase to blend in with itertools. The fact that it's a class is an
-    # implementation detail.
-
-    # TODO: Liberate into itertools.
-
-    def __init__(self, iterable):
-        self._it = iter(iterable)
-
-    def __iter__(self):
-        return self
-
-    def __nonzero__(self):
-        try:
-            self.peek()
-        except StopIteration:
-            return False
-        return True
-
-    def peek(self):
-        """Return the item that will be next returned from ``next()``.
-
-        Raise ``StopIteration`` if there are no items left.
-
-        """
-        # TODO: Give peek a default arg. Raise StopIteration only when it isn't
-        # provided. If it is, return the arg. Just like get('key', object())
-        if not hasattr(self, '_peek'):
-            self._peek = next(self._it)
-        return self._peek
-
-    def next(self):
-        ret = self.peek()
-        del self._peek
-        return ret
-
-
 def collate(*iterables, **kwargs):
     """Return an iterable ordered collation of the already-sorted items
     from each of ``iterables``, compared by kwarg ``key``.
@@ -58,17 +20,32 @@ def collate(*iterables, **kwargs):
     descending order rather than ascending.
 
     """
-    # TODO: Liberate into the stdlib.
     key = kwargs.pop('key', lambda a: a)
     reverse = kwargs.pop('reverse', False)
-
     min_or_max = max if reverse else min
-    peekables = [peekable(it) for it in iterables]
-    peekables = [p for p in peekables if p]  # Kill empties.
-    while peekables:
-        _, p = min_or_max((key(p.peek()), p) for p in peekables)
-        yield p.next()
-        peekables = [p for p in peekables if p]
+
+    rows = [iter(iterable) for iterable in iterables if iterable]
+    next_values = {}
+    by_key = []
+
+    def gather_next_value(row, index):
+        try:
+            next_value = next(row)
+        except StopIteration:
+            pass
+        else:
+            next_values[index] = next_value
+            by_key.append((key(next_value), index))
+
+    for index, row in enumerate(rows):
+        gather_next_value(row, index)
+
+    while by_key:
+        key_value, index = min_or_max(by_key)
+        by_key.remove((key_value, index))
+        next_value = next_values.pop(index)
+        yield next_value
+        gather_next_value(rows[index], index)
 
 
 def hash_to_unsigned(data):

--- a/tidings/utils.py
+++ b/tidings/utils.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage
 from django.template import Context, loader
+from django.utils.six import next, string_types
 
 try:
     from django.utils.importlib import import_module
@@ -40,7 +41,7 @@ class peekable(object):
         # TODO: Give peek a default arg. Raise StopIteration only when it isn't
         # provided. If it is, return the arg. Just like get('key', object())
         if not hasattr(self, '_peek'):
-            self._peek = self._it.next()
+            self._peek = next(self._it)
         return self._peek
 
     def next(self):
@@ -91,7 +92,7 @@ def hash_to_unsigned(data):
     filter values.
 
     """
-    if isinstance(data, basestring):
+    if isinstance(data, string_types):
         # Return a CRC32 value identical across Python versions and platforms
         # by stripping the sign bit as on
         # http://docs.python.org/library/zlib.html.

--- a/tidings/utils.py
+++ b/tidings/utils.py
@@ -1,15 +1,11 @@
 from zlib import crc32
+from importlib import import_module
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage
 from django.template import Context, loader
 from django.utils.six import next, string_types
-
-try:
-    from django.utils.importlib import import_module
-except ImportError:
-    from importlib import import_module
 
 
 def collate(*iterables, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,9 @@ deps =
     1.10: Django>=1.10,<1.11
     1.11: Django>=1.11a1,<1.12
     master: https://github.com/django/django/archive/master.tar.gz
-    -r{toxinidir}/tests/requirements.txt
+    {1.6,1.7}: -r{toxinidir}/tests/requirements-1.7.txt
+    {1.8,1.9,1.10,1.11}: -r{toxinidir}/tests/requirements-1.8.txt
+    master: -r{toxinidir}/tests/requirements-latest.txt
 whitelist_externals = make
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,32 @@
 [tox]
 args_are_paths = false
+skip_missing_interpreters = true
 envlist =
     docs,
-    {py27,py33,py34}-{1.7}
+    py{27,33}-1.6
+    py{27,33,34}-1.7
+    py{27,33,34,35}-1.8
+    py{27,34,35,36}-{1.9,1.10,1.11}
+    py{35,36}-master
 
 [testenv]
 basepython =
     py27: python2.7
     py33: python3.3
     py34: python3.4
+    py35: python3.5
+    py36: python3.6
 usedevelop = true
 pip_pre = true
 commands = make test
 deps =
     1.6: Django>=1.6,<1.7
     1.7: Django>=1.7,<1.8
+    1.8: Django>=1.8,<1.9
+    1.9: Django>=1.9,<1.10
+    1.10: Django>=1.10,<1.11
+    1.11: Django>=1.11a1,<1.12
+    master: https://github.com/django/django/archive/master.tar.gz
     -r{toxinidir}/tests/requirements.txt
 whitelist_externals = make
 


### PR DESCRIPTION
Expand the testing targets to include supported Python 3 targets for each version of Django, as well as Django 1.8 through master branch.  Update the code to be compatible with Python 3, and update the tests so that Django 1.8 tests pass.