### PR TITLE
Add flake8 testing with pep8+ fixes, improve packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,8 @@ dist/
 docs/_build/
 
 # Unit test / coverage reports
+htmlcov/
 .tox
 test.db
+.coverage
+.coverage.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
     - python: "2.7"
       env: TOXENV=docs
     - python: "2.7"
+      env: TOXENV=flake8
+    - python: "2.7"
       env: TOXENV=py27-1.6
     - python: "3.3"
       env: TOXENV=py33-1.6

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,13 @@
 include LICENSE
 include README.rst
 include Makefile
+include requirements.dev.txt
 include tox.ini
 include tests/requirements.txt
 
 recursive-include docs *.rst Makefile conf.py make.bat requirements.txt
-recursive-include tests *
-recursive-include tidings *.html *.ltxt
+recursive-include tests *.py *.html *.txt
+recursive-include tidings *.py *.html *.ltxt
+
+recursive-exclude tests *.pyc
+recursive-exclude tidings *.pyc

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,25 @@
 export DJANGO_SETTINGS_MODULE = tests.settings
 export PYTHONPATH := $(shell pwd)
 
+help:
+	@echo "clean - remove all artifacts"
+	@echo "coverage - check code coverage"
+	@echo "coveragehtml - display code coverage in browser"
+	@echo "develop - install development requirements"
+	@echo "lint - check style with flake8"
+	@echo "qa - run linters and test coverage"
+	@echo "qa-all - run QA plus packaging and cross-version tests"
+	@echo "release - package and upload a release"
+	@echo "sdist - package"
+	@echo "test - run tests"
+	@echo "test-all - run tests against eacy Django/Python version"
+	@echo "test-release - upload a release to the test PyPI server"
+
 clean:
 	git clean -Xfd
+
+develop:
+	pip install -r requirements.dev.txt
 
 shell:
 	django-admin.py shell
@@ -16,4 +33,41 @@ migrations:
 docs:
 	$(MAKE) -C docs clean html
 
-.PHONY: clean shell migrations docs test
+test-all:
+	tox --skip-missing-interpreters
+
+coverage:
+	coverage erase
+	coverage run --branch --source=tidings `which django-admin` test tests
+
+coveragehtml: coverage
+	coverage html
+	python -m webbrowser file://$(CURDIR)/htmlcov/index.html
+
+lint:
+	flake8 .
+
+qa: lint coveragehtml
+
+qa-all: qa sdist test-all
+
+sdist:
+	python setup.py sdist bdist_wheel
+	ls -l dist
+	check-manifest
+	pyroma dist/`ls -t dist | grep tar.gz | head -n1`
+
+release: clean sdist
+	twine register dist/*.tar.gz
+	twine register dist/*.whl
+	twine upload dist/*
+	python -m webbrowser -n https://pypi.python.org/pypi/django-dnt
+
+# Add [test] section to ~/.pypirc, https://testpypi.python.org/pypi
+test-release: clean sdist
+	twine register --repository test dist/*.tar.gz
+	twine register --repository test dist/*.whl
+	twine upload --repository test dist/*
+	python -m webbrowser -n https://testpypi.python.org/pypi/django-dnt
+
+.PHONY: help clean coverage coveragehtml develop lint qa qa-all release sdist test test-all test-release

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
 #
 # django-tidings documentation build configuration file, created by
 # sphinx-quickstart on Thu Mar 31 13:40:27 2011.

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,10 @@
+# Testing and development requirements
+-r tests/requirements-1.8.txt
+Django<1.9
+check-manifest
+coverage
+flake8
+pyroma
+tox
+twine
+wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 exclude =
     build,
     .tox
+
+[bdist_wheel]
+universal=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+exclude =
+    build,
+    .tox

--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,14 @@ setup(
     author_email='erik@mozilla.com',
     license='BSD',
     packages=find_packages(exclude=['tests*', 'tests']),
-    url='http://github.com/erikrose/django-tidings',
+    url='http://github.com/mozilla/django-tidings',
     include_package_data=True,
     zip_safe=False,
     install_requires=[
         'django',
-        'celery>=2.1.1'
+        'celery>=3.1'
     ],
+    keywords="django-tidings tidings email notifications",
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
@@ -37,6 +38,12 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Communications :: Email',
         'Topic :: Software Development :: Libraries :: Python Modules'],
 )

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,21 @@ import re
 from setuptools import setup, find_packages
 
 
+def long_description():
+    readme = open('README.rst').read()
+    raw_changes = open('docs/changes.rst').read()
+    # Hack symbol names out of Sphinx directives:
+    changes = re.sub(r':[a-zA-Z]+:`[0-9a-zA-Z~_\.]+\.([^`]+)`',
+                     r'``\1``',
+                     raw_changes)
+    return readme + '\n' + changes
+
+
 setup(
     name='django-tidings',
     version='1.1',
     description='Framework for asynchronous email notifications from Django',
-    long_description=open('README.rst').read() + '\n' + \
-                     # Hack symbol names out of Sphinx directives:
-                     re.sub(r':[a-zA-Z]+:`[0-9a-zA-Z~_\.]+\.([^`]+)`',
-                            r'``\1``',
-                            open('docs/changes.rst').read()),
+    long_description=long_description(),
     author='Erik Rose',
     author_email='erik@mozilla.com',
     license='BSD',

--- a/tests/base.py
+++ b/tests/base.py
@@ -15,7 +15,7 @@ from tidings.models import Watch, WatchFilter
 
 def user(save=False, **kwargs):
     defaults = {'password':
-                    'sha1$d0fcb$661bd5197214051ed4de6da4ecdabe17f5549c7c'}
+                'sha1$d0fcb$661bd5197214051ed4de6da4ecdabe17f5549c7c'}
     if 'username' not in kwargs:
         defaults['username'] = ''.join(random.choice(ascii_letters)
                                        for x in range(15))

--- a/tests/mockapp/__init__.py
+++ b/tests/mockapp/__init__.py
@@ -1,1 +1,1 @@
-
+# Mock app for testing

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -6,7 +6,11 @@ import django
 
 # Make filepaths relative to settings.
 ROOT = os.path.dirname(os.path.abspath(__file__))
-path = lambda *a: os.path.join(ROOT, *a)
+
+
+def path(*a):
+    return os.path.join(ROOT, *a)
+
 
 # Django
 DATABASES = {

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -48,8 +48,8 @@ class UsersWatchingTests(TestCase):
         """Assert that the given emails are the ones watching `event`, given
         the scoping in `filters`."""
         self.assertEqual(sorted(addresses),
-                          sorted([u.email for u, w in
-                                  event._users_watching_by_filter(**filters)]))
+                         sorted([u.email for u, w in
+                                 event._users_watching_by_filter(**filters)]))
 
     def test_simple(self):
         """Test whether a watch scoped only by event type fires for both
@@ -120,7 +120,8 @@ class UsersWatchingTests(TestCase):
               save=True)
         watch(event_type=TYPE, email='hi@there.com').save()
         watch(event_type=TYPE, email='hi@there.com').save()
-        self.assertEqual(3, Watch.objects.all().count())  # We created what we meant to.
+        # We created what we meant to.
+        self.assertEqual(3, Watch.objects.all().count())
 
         self._emails_eq(['hi@there.com'], SimpleEvent())
 
@@ -130,7 +131,8 @@ class UsersWatchingTests(TestCase):
               save=True)
         watch(event_type=TYPE, email='hi@EXAMPLE.com').save()
         watch(event_type=TYPE, email='hi@EXAMPLE.com').save()
-        self.assertEqual(3, Watch.objects.all().count())  # We created what we meant to.
+        # We created what we meant to.
+        self.assertEqual(3, Watch.objects.all().count())
 
         addresses = [u.email
                      for u, w in SimpleEvent()._users_watching_by_filter()]
@@ -191,7 +193,7 @@ class UsersWatchingTests(TestCase):
         self.assertEqual(['a'] * 3, [u.first_name for u, w in favorites[:3]])
 
     def test_unique_by_email_watch_collection(self):
-        """Make sure _unique_by_email() collects all watches in each cluster."""
+        """Ensure _unique_by_email() collects all watches in each cluster."""
         w1, w2, w3 = watch(), watch(), watch(email='hi')
         w4, w5, w6 = watch(), watch(), watch(email='lo')
         users_and_watches = [
@@ -224,8 +226,8 @@ class EventUnionTests(TestCase):
     def _emails_eq(self, addresses, event):
         """Assert that the given emails are the ones watching `event`."""
         self.assertEqual(sorted(addresses),
-                          sorted([u.email for u, w in
-                                  event._users_watching()]))
+                         sorted([u.email for u, w in
+                                 event._users_watching()]))
 
     def test_merging(self):
         """Test that duplicate emails across multiple events get merged."""
@@ -302,7 +304,9 @@ class NotificationTests(TestCase):
         """Assure notify() returns an existing watch when possible."""
         u = user(save=True)
         w = FilteredContentTypeEvent.notify(u, color=3, flavor=4)
-        self.assertEqual(w.pk, FilteredContentTypeEvent.notify(u, color=3, flavor=4).pk)
+        self.assertEqual(w.pk,
+                         FilteredContentTypeEvent.notify(u, color=3,
+                                                         flavor=4).pk)
         self.assertEqual(1, Watch.objects.all().count())
 
     def test_duplicate_tolerance(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.six.moves import range, reduce
 
@@ -14,16 +13,16 @@ class MergeTests(TestCase):
         """Test with the default `key` function."""
         iterables = [range(4), range(7), range(3, 6)]
         self.assertEqual(sorted(reduce(list.__add__,
-                                        [list(it) for it in iterables])),
-                          list(collate(*iterables)))
+                                       [list(it) for it in iterables])),
+                         list(collate(*iterables)))
 
     def test_key(self):
         """Test using a custom `key` function."""
         iterables = [range(5, 0, -1), range(4, 0, -1)]
         self.assertEqual(list(sorted(reduce(list.__add__,
-                                             [list(it) for it in iterables]),
-                                      reverse=True)),
-                          list(collate(*iterables, key=lambda x: -x)))
+                                            [list(it) for it in iterables]),
+                                     reverse=True)),
+                         list(collate(*iterables, key=lambda x: -x)))
 
     def test_empty(self):
         """Be nice if passed an empty list of iterables."""
@@ -37,9 +36,9 @@ class MergeTests(TestCase):
         """Test the `reverse` kwarg."""
         iterables = [range(4, 0, -1), range(7, 0, -1), range(3, 6, -1)]
         self.assertEqual(sorted(reduce(list.__add__,
-                                        [list(it) for it in iterables]),
-                                 reverse=True),
-                          list(collate(*iterables, reverse=True)))
+                                       [list(it) for it in iterables]),
+                                reverse=True),
+                         list(collate(*iterables, reverse=True)))
 
 
 class ImportedFromSettingTests(TestCase):
@@ -50,7 +49,8 @@ class ImportedFromSettingTests(TestCase):
         from django.db.models import Model
         assert import_from_setting('TIDINGS_MODEL_BASE', 'blah') == Model
 
-    @override_settings(TIDINGS_MODEL_BASE='hummahummanookanookanonexistent.thing')
+    @override_settings(
+            TIDINGS_MODEL_BASE='hummahummanookanookanonexistent.thing')
     def test_module_missing(self):
         self.assertRaises(ImproperlyConfigured,
                           import_from_setting, 'TIDINGS_MODEL_BASE', 'blah')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import include, patterns
 
 
-urlpatterns = patterns('',
+urlpatterns = patterns(
+    '',
     (r'^', include('tidings.urls'))
 )

--- a/tidings/events.py
+++ b/tidings/events.py
@@ -65,7 +65,8 @@ def _unique_by_email(users_and_watches):
             # Starting a new cluster.
             if cluster_email != '':
                 # Ship the favorites from the previous cluster:
-                yield ensure_user_has_email(favorite_user, cluster_email), watches
+                yield (ensure_user_has_email(favorite_user, cluster_email),
+                       watches)
             favorite_user, watches = u, []
             cluster_email = row_email
         elif ((not favorite_user.email or u.is_anonymous()) and
@@ -199,7 +200,7 @@ class Event(object):
                 joins.append(
                     'LEFT JOIN tidings_watchfilter f{n} '
                     'ON f{n}.watch_id=w.id '
-                        'AND f{n}.name=%s'.format(n=n))
+                    'AND f{n}.name=%s'.format(n=n))
                 join_params.append(k)
                 wheres.append('(f{n}.value=%s '
                               'OR f{n}.value IS NULL)'.format(n=n))
@@ -269,7 +270,8 @@ class Event(object):
         # same function to union already-list-enclosed pairs from individual
         # events.
         return _unique_by_email((u, [w]) for u, w in
-                                multi_raw(query, params, [User, Watch], model_to_fields))
+                                multi_raw(query, params, [User, Watch],
+                                          model_to_fields))
 
     @classmethod
     def _watches_belonging_to_user(cls, user_or_email, object_id=None,
@@ -305,12 +307,9 @@ class Event(object):
         # Filter by stuff in the Watch row:
         watches = getattr(Watch, 'uncached', Watch.objects).filter(
             user_condition,
-            Q(content_type=ContentType.objects.get_for_model(cls.content_type))
-                if cls.content_type
-                else Q(),
-            Q(object_id=object_id)
-                if object_id
-                else Q(),
+            Q(content_type=ContentType.objects.get_for_model(
+                cls.content_type)) if cls.content_type else Q(),
+            Q(object_id=object_id) if object_id else Q(),
             event_type=cls.event_type).extra(
                 where=['(SELECT count(*) FROM tidings_watchfilter WHERE '
                        'tidings_watchfilter.watch_id='
@@ -396,7 +395,7 @@ class Event(object):
                              for x in range(10))
             # Registered users don't need to confirm, but anonymous users do.
             is_active = ('user' in create_kwargs or
-                          not settings.TIDINGS_CONFIRM_ANONYMOUS_WATCHES)
+                         not settings.TIDINGS_CONFIRM_ANONYMOUS_WATCHES)
             if object_id:
                 create_kwargs['object_id'] = object_id
             watch = Watch.objects.create(
@@ -564,7 +563,9 @@ class InstanceEvent(Event):
 
     """
     def __init__(self, instance, *args, **kwargs):
-        """:arg instance: the instance someone would have to be watching in order to be notified when this event is fired"""
+        """:arg instance: the instance someone would have to be watching in
+        order to be notified when this event is fired
+        """
         super(InstanceEvent, self).__init__(*args, **kwargs)
         self.instance = instance
 

--- a/tidings/migrations/0001_initial.py
+++ b/tidings/migrations/0001_initial.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
 from __future__ import unicode_literals
 
 from django.db import models, migrations

--- a/tidings/models.py
+++ b/tidings/models.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.db import models, connections, router
-from django.utils.six import next
+from django.utils.six import next, text_type
 
 try:
     from django.contrib.contenttypes.fields import (GenericForeignKey,
@@ -71,8 +71,9 @@ class Watch(ModelBase):
         # TODO: Trace event_type back to find the Event subclass, and ask it
         # how to describe me in English.
         rest = self.content_object or self.content_type or self.object_id
-        return u'id=%s, type=%s, content_object=%s' % (self.pk, self.event_type,
-                                                       unicode(rest))
+        return u'id=%s, type=%s, content_object=%s' % (self.pk,
+                                                       self.event_type,
+                                                       text_type(rest))
 
     def activate(self):
         """Enable this watch so it actually fires.

--- a/tidings/south_migrations/0001_initial.py
+++ b/tidings/south_migrations/0001_initial.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
 from south.db import db
 from south.v2 import SchemaMigration
 

--- a/tidings/urls.py
+++ b/tidings/urls.py
@@ -1,7 +1,8 @@
 from django.conf.urls import patterns, url
 
 
-urlpatterns = patterns('tidings.views',
+urlpatterns = patterns(
+    'tidings.views',
     url(r'^unsubscribe/(?P<watch_id>\d+)$',
         'unsubscribe',
         name='tidings.unsubscribe')

--- a/tidings/utils.py
+++ b/tidings/utils.py
@@ -74,9 +74,9 @@ def hash_to_unsigned(data):
         return int(data)
 
 
-def emails_with_users_and_watches(subject, template_path, vars,
-    users_and_watches, from_email=settings.TIDINGS_FROM_ADDRESS,
-    **extra_kwargs):
+def emails_with_users_and_watches(
+        subject, template_path, vars, users_and_watches,
+        from_email=settings.TIDINGS_FROM_ADDRESS, **extra_kwargs):
     """Return iterable of EmailMessages with user and watch values substituted.
 
     A convenience function for generating emails by repeatedly rendering a
@@ -92,8 +92,11 @@ def emails_with_users_and_watches(subject, template_path, vars,
     context = Context(vars)
     for u, w in users_and_watches:
         context['user'] = u
-        context['watch'] = w[0]  # Arbitrary single watch for compatibility
-                                 # with 0.1. TODO: remove.
+
+        # Arbitrary single watch for compatibility with 0.1
+        # TODO: remove.
+        context['watch'] = w[0]
+
         context['watches'] = w
         yield EmailMessage(subject,
                            template.render(context),

--- a/tidings/views.py
+++ b/tidings/views.py
@@ -23,8 +23,8 @@ def unsubscribe(request, watch_id):
     # Grab the watch and secret; complain if either is wrong:
     try:
         watch = Watch.objects.get(pk=watch_id)
-        secret = request.GET.get('s')  # 's' is for 'secret' but saves wrapping
-                                       # in mails
+        # 's' is for 'secret' but saves wrapping in mails
+        secret = request.GET.get('s')
         if secret != watch.secret:
             raise Watch.DoesNotExist
     except Watch.DoesNotExist:

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ args_are_paths = false
 skip_missing_interpreters = true
 envlist =
     docs,
+    flake8,
     py{27,33}-1.6
     py{27,33,34}-1.7
     py{27,33,34,35}-1.8
@@ -36,3 +37,8 @@ whitelist_externals = make
 basepython = python2.7
 deps = -r{toxinidir}/docs/requirements.txt
 commands = make docs
+
+[testenv:flake8]
+basepython = python2.7
+deps = flake8
+commands = make lint


### PR DESCRIPTION
Various changes in preparation for a new release (short of a version bump and release notes):

* Expand ``Makefile`` with additional QA and packaging commands, along with developer-specific requirements.
* Adjust comments, whitespace, etc. to make [flake8](http://flake8.pycqa.org/en/latest/) happy.  Add a "flake8" test to Travis to maintain it.
* Update packaging as suggested by [check-manifest](https://github.com/mgedmin/check-manifest) (mostly excluding ``*.pyc`` files) and [pyroma](https://bitbucket.org/regebro/pyroma) (adding keywords, Python specifiers).
* Fix a Python 3 bug (Switch ``Watch.__unicode__`` from Python2-only ``unicode`` to six's ``text_type``)
* Mark wheel as universal
* Update project URL