### PR TITLE
Release 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ matrix:
     - python: "2.7"
       env: TOXENV=flake8
     - python: "2.7"
-      env: TOXENV=py27-1.6
-    - python: "3.3"
-      env: TOXENV=py33-1.6
-    - python: "2.7"
       env: TOXENV=py27-1.7
     - python: "3.4"
       env: TOXENV=py34-1.7

--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,13 @@ release: clean sdist
 	twine register dist/*.tar.gz
 	twine register dist/*.whl
 	twine upload dist/*
-	python -m webbrowser -n https://pypi.python.org/pypi/django-dnt
+	python -m webbrowser -n https://pypi.python.org/pypi/django-tidings
 
 # Add [test] section to ~/.pypirc, https://testpypi.python.org/pypi
 test-release: clean sdist
 	twine register --repository test dist/*.tar.gz
 	twine register --repository test dist/*.whl
 	twine upload --repository test dist/*
-	python -m webbrowser -n https://testpypi.python.org/pypi/django-dnt
+	python -m webbrowser -n https://testpypi.python.org/pypi/django-tidings
 
 .PHONY: help clean coverage coveragehtml develop lint qa qa-all release sdist test test-all test-release

--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@ django-tidings
 .. image:: https://img.shields.io/coveralls/mozilla/django-tidings.svg
    :target: https://coveralls.io/github/mozilla/django-tidings
 
-.. image:: https://readthedocs.org/projects/django-tidings/badge/?version=latest&style=plastic
-   :target: http://django-tidings.readthedocs.org/en/latest/
+.. image:: https://readthedocs.org/projects/django-tidings/badge/
+   :target: https://django-tidings.readthedocs.io/en/latest/
 
 .. Omit badges from docs
 
@@ -28,4 +28,4 @@ installations. Its features include...
 * Optional confirmation of anonymous subscriptions
 * Hook points for customizing any page drawn and any email sent
 
-Please see the full documentation at http://django-tidings.readthedocs.org/
+Please see the full documentation at https://django-tidings.readthedocs.io/en/latest/

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,8 @@ django-tidings
 .. image:: https://readthedocs.org/projects/django-tidings/badge/?version=latest&style=plastic
    :target: http://django-tidings.readthedocs.org/en/latest/
 
+.. Omit badges from docs
+
 django-tidings is a framework for sending email notifications to users who have
 registered interest in certain events, such as the modification of some model
 object. Used by support.mozilla.com, it is optimized for large-scale

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,10 @@ django-tidings
    :target: https://pypi.python.org/pypi/django-tidings
 
 .. image:: https://img.shields.io/travis/mozilla/django-tidings.svg
-    :target: http://travis-ci.org/mozilla/django-tidings
+   :target: http://travis-ci.org/mozilla/django-tidings
+
+.. image:: https://img.shields.io/coveralls/mozilla/django-tidings.svg
+   :target: https://coveralls.io/github/mozilla/django-tidings
 
 .. image:: https://readthedocs.org/projects/django-tidings/badge/?version=latest&style=plastic
    :target: http://django-tidings.readthedocs.org/en/latest/

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,10 @@
 Version History
 ===============
 
+1.2 (2017-03-22)
+  * Added support for Django 1.8 and Python 3
+  * Dropped support for Python 2.6
+
 1.1 (2015-04-23)
   * Added support for Django 1.7
   * Dropped support for Django 1.4, 1.5 and 1.6

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,7 +7,7 @@ Version History
   * Dropped mock, Fabric and django-nose dependencies.
   * Moved tests outside of app and simplified test setup.
   * Added Travis CI: https://travis-ci.org/mozilla/django-tidings
-  * Moved to ReadTheDocs: http://django-tidings.readthedocs.org/
+  * Moved to ReadTheDocs: https://django-tidings.readthedocs.io/
 
 1.0 (2015-03-03)
   * Support Django 1.6.

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -6,7 +6,7 @@ Testing
 =======
 
 To run django-tidings' tests, install
-`tox <http://tox.readthedocs.org/en/latest/>`_ and run it::
+`tox <https://tox.readthedocs.io/en/latest/>`_ and run it::
 
   $ pip install tox
   $ tox

--- a/setup.py
+++ b/setup.py
@@ -2,21 +2,37 @@ import re
 
 from setuptools import setup, find_packages
 
+description = 'Framework for asynchronous email notifications from Django'
+
 
 def long_description():
-    readme = open('README.rst').read()
+    raw_readme = open('README.rst').read()
+    body_tag = ".. Omit badges from docs"
+    readme = raw_readme[raw_readme.index(body_tag) + len(body_tag) + 1:]
     raw_changes = open('docs/changes.rst').read()
     # Hack symbol names out of Sphinx directives:
     changes = re.sub(r':[a-zA-Z]+:`[0-9a-zA-Z~_\.]+\.([^`]+)`',
                      r'``\1``',
                      raw_changes)
-    return readme + '\n' + changes
+    return """\
+%(title_mark)s
+%(title)s
+%(title_mark)s
+%(readme)s
+
+%(changes)s
+""" % {
+            'title_mark': '=' * len(description),
+            'title': description,
+            'readme': readme,
+            'changes': changes,
+        }
 
 
 setup(
     name='django-tidings',
     version='1.1',
-    description='Framework for asynchronous email notifications from Django',
+    description=description,
     long_description=long_description(),
     author='Erik Rose',
     author_email='erik@mozilla.com',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def long_description():
 
 setup(
     name='django-tidings',
-    version='1.1',
+    version='1.2',
     description=description,
     long_description=long_description(),
     author='Erik Rose',

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,9 @@ basepython =
     py36: python3.6
 usedevelop = true
 pip_pre = true
-commands = make test
+commands = make coverage
 deps =
+    coverage
     1.6: Django>=1.6,<1.7
     1.7: Django>=1.7,<1.8
     1.8: Django>=1.8,<1.9

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ skip_missing_interpreters = true
 envlist =
     docs,
     flake8,
-    py{27,33}-1.6
     py{27,33,34}-1.7
     py{27,33,34,35}-1.8
     py{27,34,35,36}-{1.9,1.10,1.11}
@@ -22,14 +21,13 @@ pip_pre = true
 commands = make coverage
 deps =
     coverage
-    1.6: Django>=1.6,<1.7
     1.7: Django>=1.7,<1.8
     1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
     1.10: Django>=1.10,<1.11
     1.11: Django>=1.11a1,<1.12
     master: https://github.com/django/django/archive/master.tar.gz
-    {1.6,1.7}: -r{toxinidir}/tests/requirements-1.7.txt
+    1.7: -r{toxinidir}/tests/requirements-1.7.txt
     {1.8,1.9,1.10,1.11}: -r{toxinidir}/tests/requirements-1.8.txt
     master: -r{toxinidir}/tests/requirements-latest.txt
 whitelist_externals = make


### PR DESCRIPTION
Bump version to 1.2 with release notes, and because I CAN'T STOP, more changes:

* Fix path on PyPI
* Add badge for coveralls.io (and enable for the project, so will be unknown until merge)
* Drop Django 1.6 from TravisCI, because can't run coverage against it
* Change project doc links from readthedocs.org to readthedocs.io
* Omit badges from PyPI description

Demo on test PyPI server (for a little bit) at https://testpypi.python.org/pypi/django-tidings. Weird version number 1.2.0 is because PyPI doesn't let you upload a second time with the exact same release number.