### PR TITLE
Drop django-celery, update to Celery 4.x, allow avoiding Pickle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export DJANGO_SETTINGS_MODULE = tests.settings
+export DJANGO_SETTINGS_MODULE = tests.mockapp.settings
 export PYTHONPATH := $(shell pwd)
 
 help:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,8 +3,12 @@ Version History
 
 2.0 (To Be Released)
   * Dropped support for Django 1.7 and South.
-  * Migrates Watch.email from a maximum length of 75 to 254, to follow the
+  * Added ``Event.fire(delay=False)``, to avoid using the
+    pickle serializer, which has `security concerns`_.
+  * Migrated Watch.email from a maximum length of 75 to 254, to follow the
     EmailField update in Django 1.8.
+
+.. _`security concerns`: http://docs.celeryproject.org/en/latest/userguide/security.html#serializers
 
 1.2 (2017-03-22)
   * Added support for Django 1.8 and Python 3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ import sys, os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
-os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
+os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.mockapp.settings'
 
 # -- General configuration -----------------------------------------------------
 

--- a/tests/mockapp/__init__.py
+++ b/tests/mockapp/__init__.py
@@ -1,1 +1,5 @@
 # Mock app for testing
+from __future__ import absolute_import, unicode_literals
+from .celery import app as celery_app
+
+__all__ = ['celery_app']

--- a/tests/mockapp/celery.py
+++ b/tests/mockapp/celery.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import, unicode_literals
+import os
+from celery import Celery
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.mockapp.settings')
+app = Celery('mockapp')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks()

--- a/tests/mockapp/settings.py
+++ b/tests/mockapp/settings.py
@@ -1,4 +1,3 @@
-import djcelery
 import os
 
 import django
@@ -24,7 +23,6 @@ INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sites',
-    'djcelery',
     'tidings',
     'tests',
     'tests.mockapp',
@@ -56,9 +54,8 @@ TEMPLATE_LOADERS = (
 JINGO_INCLUDE_PATTERN = r'\.html'
 
 # Celery
-djcelery.setup_loader()
-CELERY_ALWAYS_EAGER = True
-CELERY_EAGER_PROPAGATES_EXCEPTIONS = True  # Explode loudly during tests.
+CELERY_TASK_ALWAYS_EAGER = True
+CELERY_TASK_EAGER_PROPAGATES = True  # Explode loudly during tests.
 
 # Tidings
 TIDINGS_FROM_ADDRESS = 'nobody@example.com'

--- a/tests/requirements-1.8.txt
+++ b/tests/requirements-1.8.txt
@@ -1,4 +1,3 @@
 # Requirements for Django 1.8
 jingo==0.9.0
-celery==3.1.18
-django-celery==3.2.1
+celery==4.1.0

--- a/tests/requirements-latest.txt
+++ b/tests/requirements-latest.txt
@@ -1,4 +1,3 @@
 # Latest versions of requirements
 jingo
 celery
-django-celery

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -372,16 +372,23 @@ class MailTests(TestCase):
     """Tests for mail-sending and templating"""
 
     @override_settings(TIDINGS_CONFIRM_ANONYMOUS_WATCHES=False)
-    def test_fire(self):
+    def test_fire(self, delay=True):
         """Assert that fire() runs and that generated mails get sent."""
         SimpleEvent.notify('hi@there.com').activate().save()
-        SimpleEvent().fire()
+        SimpleEvent().fire(delay=delay)
 
         self.assertEqual(1, len(mail.outbox))
         first_mail = mail.outbox[0]
         self.assertEqual(['hi@there.com'], first_mail.to)
         self.assertEqual('Subject!', first_mail.subject)
         self.assertEqual('Body!', first_mail.body)
+
+    def test_fire_no_delay(self):
+        """Assert that file(delay=False) also sends emails.
+
+        This processes the event synronously, rather than as a Celery task.
+        """
+        self.test_fire(delay=False)
 
     def test_anonymous_notify_and_fire(self):
         """Calling notify() sends confirmation email, and calling fire() sends

--- a/tidings/events.py
+++ b/tidings/events.py
@@ -112,7 +112,7 @@ class Event(object):
         """Notify everyone watching the event.
 
         We are explicit about sending notifications; we don't just key off
-        creation signals, because the receiver of a post_save signal has no
+        creation signals, because the receiver of a ``post_save`` signal has no
         idea what just changed, so it doesn't know which notifications to send.
         Also, we could easily send mail accidentally: for instance, during
         tests. If we want implicit event firing, we can always register a
@@ -569,11 +569,12 @@ class InstanceEvent(Event):
 
     Subclasses must specify an ``event_type`` and should specify a
     ``content_type``.
-
     """
     def __init__(self, instance, *args, **kwargs):
-        """:arg instance: the instance someone would have to be watching in
-        order to be notified when this event is fired
+        """Initialize an InstanceEvent
+
+        :arg instance: the instance someone would have to be watching in
+          order to be notified when this event is fired.
         """
         super(InstanceEvent, self).__init__(*args, **kwargs)
         self.instance = instance

--- a/tidings/events.py
+++ b/tidings/events.py
@@ -1,6 +1,6 @@
 from collections import Sequence
-import random
 from smtplib import SMTPException
+import random
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -108,8 +108,8 @@ class Event(object):
     #: ``set(['color', 'flavor'])``
     filters = set()
 
-    def fire(self, exclude=None):
-        """Asynchronously notify everyone watching the event.
+    def fire(self, exclude=None, delay=True):
+        """Notify everyone watching the event.
 
         We are explicit about sending notifications; we don't just key off
         creation signals, because the receiver of a post_save signal has no
@@ -122,9 +122,18 @@ class Event(object):
           notified, though anonymous notifications having the same email
           address may still be sent. A sequence of users may also be passed in.
 
+        :arg delay: If True (default), the event is handled asynchronously with
+          Celery. This requires the pickle task serializer, which is no longer
+          the default starting in Celery 4.0. If False, the event is processed
+          immediately.
         """
-        # Tasks don't receive the `self` arg implicitly.
-        self._fire_task.delay(self, exclude=exclude)
+        if delay:
+            # Tasks don't receive the `self` arg implicitly.
+            self._fire_task.apply_async(
+                kwargs={'self': self, 'exclude': exclude},
+                serializer='pickle')
+        else:
+            self._fire_task(self, exclude=exclude)
 
     @task
     def _fire_task(self, exclude=None):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters = true
 envlist =
     docs,
     flake8,
-    py{27,33,34,35}-1.8
+    py{27,34,35}-1.8
     py{27,34,35,36}-{1.9,1.10,1.11}
     py{35,36}-master
 


### PR DESCRIPTION
For the test application, use the [recommended way to integrate with Django](http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html), dropping the deprecated [django-celery](https://github.com/celery/django-celery) library and updating to [Celery 4.0](http://docs.celeryproject.org/en/latest/whatsnew-4.0.html).

``Event.fire()`` uses the [pickle](https://docs.python.org/3/library/pickle.html) serializer, which is still supported but not recommended.  There is now an option ``Event.fire(delay=False)`` that avoids ``pickle`` by processing the event directly. This can be used in combination with a user-written Celery task to avoid ``pickle`` and use a safer serializer, such as ``json``.






Fixes issue #33.