### PR TITLE
Drop jingo, ship standard Django templates

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,12 +3,15 @@ Version History
 
 2.0 (To Be Released)
   * Dropped support for Django 1.7 and South.
+  * Dropped support for jingo_. Templates for the ``unsubscribe`` view are now
+    standard Django templates.
   * Added ``Event.fire(delay=False)``, to avoid using the
     pickle serializer, which has `security concerns`_.
   * Migrated Watch.email from a maximum length of 75 to 254, to follow the
     EmailField update in Django 1.8.
 
 .. _`security concerns`: http://docs.celeryproject.org/en/latest/userguide/security.html#serializers
+.. _jingo: https://github.com/jbalogh/jingo
 
 1.2 (2017-03-22)
   * Added support for Django 1.8 and Python 3

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,9 @@ Version History
     standard Django templates.
   * Added ``Event.fire(delay=False)``, to avoid using the
     pickle serializer, which has `security concerns`_.
+  * Added setting ``TIDINGS_TEMPLATE_EXTENSION`` to allow changing the
+    template extension used by the ``unsubscribe`` view from ``html`` to
+    ``jinja``, ``j2``, etc.
   * Migrated Watch.email from a maximum length of 75 to 254, to follow the
     EmailField update in Django 1.8.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -62,3 +62,22 @@ django-tidings offers several Django settings to customize its behavior:
   Example::
     
     TIDINGS_REVERSE = 'sumo.urlresolvers.reverse'
+
+
+.. data:: TIDINGS_TEMPLATE_EXTENSION
+
+  The extension for tidings view templates. It can be changed to support
+  alternate template libraries like django-jinja_.  The extension is
+  used in the :func:`~tidings.views.unsubscribe` view:
+
+  * ``'tidings/unsubscribe.'`` + ``TIDINGS_TEMPLATE_EXTENSION``
+  * ``'tidings/unsubscribe_error.'`` + ``TIDINGS_TEMPLATE_EXTENSION``
+  * ``'tidings/unsubscribe_success.'`` + ``TIDINGS_TEMPLATE_EXTENSION``
+
+  Default: ``'html'``
+
+  Example::
+
+     TIDINGS_TEMPLATE_EXTENSION = 'jinja'
+
+.. _django-jinja: http://niwinz.github.io/django-jinja/latest/

--- a/tests/mockapp/settings.py
+++ b/tests/mockapp/settings.py
@@ -33,25 +33,9 @@ if django.VERSION[:2] < (1, 7):
 
 ROOT_URLCONF = 'tests.urls'
 SITE_ID = 1
-TEMPLATE_DEBUG = True
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 MIDDLEWARE_CLASSES = []
-
-# Jinja
-TEMPLATE_DIRS = [
-    # Put strings here, like "/home/html/django_templates"
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    path('templates')
-]
-TEMPLATE_LOADERS = (
-    'jingo.Loader',
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-    # 'django.template.loaders.eggs.Loader',
-)
-JINGO_INCLUDE_PATTERN = r'\.html'
 
 # Celery
 CELERY_TASK_ALWAYS_EAGER = True

--- a/tests/requirements-1.8.txt
+++ b/tests/requirements-1.8.txt
@@ -1,3 +1,2 @@
 # Requirements for Django 1.8
-jingo==0.9.0
 celery==4.1.0

--- a/tests/requirements-latest.txt
+++ b/tests/requirements-latest.txt
@@ -1,3 +1,2 @@
 # Latest versions of requirements
-jingo
 celery

--- a/tests/templates/base.html
+++ b/tests/templates/base.html
@@ -1,1 +1,0 @@
-{% block content %}{% endblock %}

--- a/tidings/templates/base.html
+++ b/tidings/templates/base.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{% block head_title %}{% endblock %}</title>
+  </head>
+  <body>
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/tidings/templates/tidings/base.html
+++ b/tidings/templates/tidings/base.html
@@ -1,0 +1,1 @@
+{% extends "base.html" %}

--- a/tidings/templates/tidings/unsubscribe.html
+++ b/tidings/templates/tidings/unsubscribe.html
@@ -1,18 +1,17 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
-{% extends "base.html" %}
-{% set title = _('Unsubscribe') %}
-{% set crumbs = [(None, title)] %}
+{% extends "tidings/base.html" %}
+{% load i18n %}
+
+{% block head_title %}{% trans "Unsubscribe" %}{% endblock %}
 
 {% block content %}
-  <article class="main">
-    <h1 class="title">{{ _('Are you sure you want to unsubscribe?') }}</h1>
-    {# TODO: Once Watches know how to describe themselves, print that description. #}
-    <form action="" method="post">
-      {{ csrf() }}
-      <div class="submit-or-cancel">
-        <input type="submit" value="{{ _('Unsubscribe') }}" />
-        <a href="/"{# Discards l10n. Better ideas? #}>{{ _('Cancel') }}</a>
-      </div>
-    </form>
-  </article>
+  <h1>{% trans "Are you sure you want to unsubscribe?" %}</h1>
+  {# TODO: Once Watches know how to describe themselves, print that description. #}
+  <form action="" method="post">
+    {% csrf_token %}
+    <div class="submit-or-cancel">
+      <input type="submit" value="{% trans "Unsubscribe" %}" />
+      <a href="/"{# Discards l10n. Better ideas? #}>{% trans "Cancel" %}</a>
+    </div>
+  </form>
 {% endblock %}

--- a/tidings/templates/tidings/unsubscribe_error.html
+++ b/tidings/templates/tidings/unsubscribe_error.html
@@ -1,20 +1,20 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
-{% extends "base.html" %}
-{% set title = _('Unsubscribe') %}
-{% set crumbs = [(None, title)] %}
+{% extends "tidings/base.html" %}
+
+{% load i18n %}
+
+{% block head_title %}{% trans "Unsubscribe" %}{% endblock %}
 
 {% block content %}
-<article class="main">
-  <h1>{{ _('Unsubscribe Error') }}</h1>
-
+  <h1>{% trans "Unsubscribe Error" %}</h1>
   <p>
-    {% trans %}
+    {% blocktrans trimmed %}
       We could not find your subscription. Either it has already been
       cancelled, or there was a mistake in the unsubscribe link. Please make
       sure the entire link from the email made it into the browser. If the last
       part of the link wraps onto a second line in the email, try copying and
       pasting the link into the browser.
-    {% endtrans %}
+    {% endblocktrans %}
   </p>
 </article>
 {% endblock %}

--- a/tidings/templates/tidings/unsubscribe_success.html
+++ b/tidings/templates/tidings/unsubscribe_success.html
@@ -1,12 +1,12 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
-{% extends "base.html" %}
-{% set title = _('Unsubscribe') %}{# Having this change to "Unsubscribed" draws my eye and bothers me. #}
-{% set crumbs = [(None, title)] %}
+{% extends "tidings/base.html" %}
+{% load i18n %}
+
+{# Having this change to "Unsubscribed" draws my eye and bothers me. #}
+{% block head_title %}{% trans "Unsubscribe" %}{% endblock %}
 
 {% block content %}
-<article class="main">
-  <h1>{{ _('Unsubscribed') }}</h1>
+<h1>{% trans "Unsubscribed" %}</h1>
 
-  <p>{{ _('You have been unsubscribed.') }}</p>
-</article>
+<p>{% trans "You have been unsubscribed." %}</p>
 {% endblock %}

--- a/tidings/views.py
+++ b/tidings/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.shortcuts import render
 
 from tidings.models import Watch
@@ -20,7 +21,12 @@ def unsubscribe(request, watch_id):
 
     The shipped templates assume a ``head_title`` and a ``content`` block
     in a ``base.html`` template.
+
+    The template extension can be changed from the default ``html`` using
+    the setting :data:`~django.conf.settings.TIDINGS_TEMPLATE_EXTENSION`.
     """
+    ext = getattr(settings, 'TIDINGS_TEMPLATE_EXTENSION', 'html')
+
     # Grab the watch and secret; complain if either is wrong:
     try:
         watch = Watch.objects.get(pk=watch_id)
@@ -29,10 +35,10 @@ def unsubscribe(request, watch_id):
         if secret != watch.secret:
             raise Watch.DoesNotExist
     except Watch.DoesNotExist:
-        return render(request, 'tidings/unsubscribe_error.html')
+        return render(request, 'tidings/unsubscribe_error.' + ext)
 
     if request.method == 'POST':
         watch.delete()
-        return render(request, 'tidings/unsubscribe_success.html')
+        return render(request, 'tidings/unsubscribe_success.' + ext)
 
-    return render(request, 'tidings/unsubscribe.html')
+    return render(request, 'tidings/unsubscribe.' + ext)

--- a/tidings/views.py
+++ b/tidings/views.py
@@ -12,13 +12,14 @@ def unsubscribe(request, watch_id):
     wrong). POST will actually delete the watch (again, if the secret is
     correct).
 
-    The templates assume use of the Jinja templating engine via jingo.Loader
-    and the presence of a ``base.html`` template containing a ``content``
-    block.
+    Uses these templates:
 
-    If you aren't using Jinja via jingo.Loader, you can replace the templates
-    with your own django templates.
+    * tidings/unsubscribe.html - Asks user to confirm deleting a watch
+    * tidings/unsubscribe_error.html - Shown when a watch is not found
+    * tidings/unsubscribe_success.html - Shown when a watch is deleted
 
+    The shipped templates assume a ``head_title`` and a ``content`` block
+    in a ``base.html`` template.
     """
     # Grab the watch and secret; complain if either is wrong:
     try:


### PR DESCRIPTION
Drop the deprecated [jingo](https://github.com/jbalogh/jingo) library, and convert the templates for the ``unsubscribe`` view to standard Django templates.  Add a setting ``TIDINGS_TEMPLATE_EXTENSION`` to allow loading alternative templates like ``unsubscribe.jinja`` with [django-jinja](https://github.com/niwinz/django-jinja). Fixes #32.