### PR TITLE
Release 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011, The Mozilla Foundation
+Copyright (c) 2011-2018, The Mozilla Foundation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Makefile
+++ b/Makefile
@@ -58,15 +58,15 @@ sdist:
 	pyroma dist/`ls -t dist | grep tar.gz | head -n1`
 
 release: clean sdist
-	twine register dist/*.tar.gz
-	twine register dist/*.whl
+	gpg --detach-sign -a dist/*.tar.gz
+	gpg --detach-sign -a dist/*.whl
 	twine upload dist/*
 	python -m webbrowser -n https://pypi.python.org/pypi/django-tidings
 
 # Add [test] section to ~/.pypirc, https://testpypi.python.org/pypi
 test-release: clean sdist
-	twine register --repository test dist/*.tar.gz
-	twine register --repository test dist/*.whl
+	gpg --detach-sign -a dist/*.tar.gz
+	gpg --detach-sign -a dist/*.whl
 	twine upload --repository test dist/*
 	python -m webbrowser -n https://testpypi.python.org/pypi/django-tidings
 

--- a/README.rst
+++ b/README.rst
@@ -18,14 +18,19 @@ django-tidings
 
 django-tidings is a framework for sending email notifications to users who have
 registered interest in certain events, such as the modification of some model
-object. Used by support.mozilla.com, it is optimized for large-scale
-installations. Its features include...
+object. Used by support.mozilla.org_ and developer.mozilla.org_, it is
+optimized for large-scale installations. Its features include...
 
-* Asynchronous operation using the ``celery`` task queue
+* Asynchronous operation using the celery_ task queue
 * De-duplication of notifications
 * Association of subscriptions with either registered Django users or anonymous
   email addresses
 * Optional confirmation of anonymous subscriptions
 * Hook points for customizing any page drawn and any email sent
 
-Please see the full documentation at https://django-tidings.readthedocs.io/en/latest/
+Please see the full documentation at django-tidings.readthedocs.io_.
+
+.. _celery: http://www.celeryproject.org/
+.. _support.mozilla.org: https://support.mozilla.org/en-US/
+.. _developer.mozilla.org: https://developer.mozilla.org/en-US/
+.. _django-tidings.readthedocs.io: https://django-tidings.readthedocs.io/en/latest/

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,7 +1,7 @@
 Version History
 ===============
 
-2.0 (To Be Released)
+2.0 (2018-02-10)
   * Added support for Django 1.9, 1.10, 1.11, and 2.0.
   * Dropped support for Django 1.7 and South.
   * Dropped support for jingo_. Templates for the ``unsubscribe`` view are now

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from datetime import date
 import sys, os
 import django
 
@@ -45,7 +46,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'django-tidings'
-copyright = u'Mozilla'
+copyright = u'2011-%d, The Mozilla Foundation' % date.today().year
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,8 +4,8 @@ django-tidings
 
 django-tidings is a framework for sending email notifications to users who have
 registered interest in certain events, such as the modification of some model
-object. Used by support.mozilla.com, it is optimized for large-scale
-installations. Its features include...
+object. Used by support.mozilla.org_ and developer.mozilla.org_, it is
+optimized for large-scale installations. Its features include...
 
 * Asynchronous operation using the celery_ task queue
 * De-duplication of notifications
@@ -14,6 +14,8 @@ installations. Its features include...
 * Optional confirmation of anonymous subscriptions
 * Hook points for customizing any page drawn and any email sent
 
+.. _support.mozilla.org: https://support.mozilla.org/en-US/
+.. _developer.mozilla.org: https://developer.mozilla.org/en-US/
 .. _celery: http://www.celeryproject.org/
 
 Contents
@@ -40,9 +42,42 @@ Indices and tables
 
 Credits
 =======
+`Erik Rose`_ and `Paul Craciunoiu`_ developed django-tidings, replacing
+a simpler progenitor written by the whole `support.mozilla.com team`_,
+including `Ricky Rosario`_ and `James Socol`_.
 
-django-tidings was developed by Erik Rose and Paul Craciunoiu, replacing a
-simpler progenitor written by the whole support.mozilla.com team, including
-Ricky Rosario and James Socol.
+`Will Kahn-Greene`_ worked on the 1.0 release. He updated the project to Django
+1.4 through 1.6, added tox_ support to make multi-version testing easier, and
+fixed bugs.
+
+`Jannis Leidel`_ worked on the 1.1 release. He updated the project to Django 1.7
+and 1.8, added South_ migrations, refactored tests, added TravisCI_ and
+Coveralls_ support, switched from Fabric_ to a Makefile, switched from mock_ and
+django_nose_ to Django tests, and more.
+
+`John Whitlock`_ worked on the 1.2 and 2.0 releases. He added support for
+Python 3 and Django 1.9 through 2.0. He added linting with flake8_, switched
+from jingo_ to Django templates, and switched from django_celery_ to basic
+Celery_.
+
+.. _`Erik Rose`: https://github.com/erikrose
+.. _`Paul Craciunoiu`: https://github.com/pcraciunoiu
+.. _`Ricky Rosario`: https://github.com/rlr
+.. _`James Socol`: https://github.com/jsocol
+.. _`Will Kahn-Greene`: https://github.com/willkg
+.. _`Jannis Leidel`: https://github.com/jezdez
+.. _`John Whitlock`: https://github.com/jwhitlock
+.. _`support.mozilla.com team`: https://github.com/mozilla/kitsune
+.. _tox: https://tox.readthedocs.io/en/latest/
+.. _South: http://south.aeracode.org/
+.. _Fabric: http://www.fabfile.org/
+.. _TravisCI: https://travis-ci.org/mozilla/django-tidings
+.. _Coveralls: https://coveralls.io/github/mozilla/django-tidings
+.. _mock: https://github.com/testing-cabal/mock
+.. _django_nose: https://github.com/django-nose/django-nose
+.. _flake8: http://flake8.pycqa.org/en/latest/
+.. _jingo: https://github.com/jbalogh/jingo
+.. _django_celery: https://github.com/celery/django-celery
+.. _Celery: http://www.celeryproject.org/
 
 .. Add your name if you commit something!

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def long_description():
 
 setup(
     name='django-tidings',
-    version='1.2',
+    version='2.0',
     description=description,
     long_description=long_description(),
     author='Erik Rose',
@@ -49,6 +49,11 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
@@ -57,9 +62,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Communications :: Email',
         'Topic :: Software Development :: Libraries :: Python Modules'],
 )


### PR DESCRIPTION
* Added support for Django 1.9, 1.10, 1.11, and 2.0.
* Dropped support for Django 1.7 and South.
* Dropped support for [jingo](https://github.com/jbalogh/jingo). Templates for the ``unsubscribe`` view are now standard Django templates.
* Added ``Event.fire(delay=False)``, to avoid using the pickle serializer, which has [security concerns](http://docs.celeryproject.org/en/latest/userguide/security.html#serializers).
* Added setting ``TIDINGS_TEMPLATE_EXTENSION`` to allow changing the template extension used by the ``unsubscribe`` view from ``html`` to ``jinja``, ``j2``, etc.
* Migrated Watch.email from a maximum length of 75 to 254, to follow the ``EmailField`` update in Django 1.8.

Fixes #34.