### PR TITLE
Release 2.0.1: Fix bug in async Event.fire()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,10 @@
 Version History
 ===============
 
+2.0.1 (2018-02-14)
+  * Fix a bug where asynchronously firing a task (the default) would
+    raise an exception when run via Celery.
+
 2.0 (2018-02-10)
   * Added support for Django 1.9, 1.10, 1.11, and 2.0.
   * Dropped support for Django 1.7 and South.

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def long_description():
 
 setup(
     name='django-tidings',
-    version='2.0',
+    version='2.0.1',
     description=description,
     long_description=long_description(),
     author='Erik Rose',

--- a/tidings/events.py
+++ b/tidings/events.py
@@ -131,7 +131,8 @@ class Event(object):
         if delay:
             # Tasks don't receive the `self` arg implicitly.
             self._fire_task.apply_async(
-                kwargs={'self': self, 'exclude': exclude},
+                args=(self,),
+                kwargs={'exclude': exclude},
                 serializer='pickle')
         else:
             self._fire_task(self, exclude=exclude)


### PR DESCRIPTION
Passes ``self`` in ``args``, not in ``kwargs``. Fixes #40, Bumps the PATCH version to 2.0.1.

❤️ Happy Valentines Day! ❤️ 
