### PR TITLE
Add Mozilla Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+# Community Participation Guidelines
+
+This repository is governed by Mozilla's code of conduct and etiquette guidelines.
+For more details, please read the
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
+
+## How to Report
+For more information on how to report violations of the Community Participation
+Guidelines, please read our
+[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/) page.


### PR DESCRIPTION
Add Mozilla Code of Conduct, with markdown linting fixes. Replaces #43, fixes #42