### PR TITLE
Add Python 3.8, Django 3.0 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: python
 cache: pip
 matrix:
   include:
-    - python: "2.7"
+    - python: "3.6"
       env: TOXENV=docs
-    - python: "2.7"
+    - python: "3.6"
       env: TOXENV=flake8
     - python: "2.7"
       env: TOXENV=py27-1.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
       env: TOXENV=flake8
     - python: "2.7"
       env: TOXENV=py27-1.11
-    - python: "3.4"
-      env: TOXENV=py34-1.11
+    - python: "3.5"
+      env: TOXENV=py35-1.11
     - python: "3.5"
       env: TOXENV=py35-2.1
     - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,13 @@ matrix:
       env: TOXENV=py36-2.2
       dist: xenial  # For SQLite 3.8.3 or later
     - python: "3.7"
-      env: TOXENV=py37-master
+      env: TOXENV=py37-3.0
       dist: xenial  # For Python 3.7
+    - python: "3.8"
+      env: TOXENV=py38-master
+      dist: xenial  # For Python 3.8
   allow_failures:
-    - env: TOXENV=py37-master
+    - env: TOXENV=py38-master
 install:
   - pip install tox
 script:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.rst
+include CODE_OF_CONDUCT.md
 include Makefile
 include requirements.dev.txt
 include tox.ini

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,12 @@
 Version History
 ===============
 
+Unreleased
+  * Drop support for Django 1.9, 1.10
+  * Add support for Django 2.1, 2.2, and 3.0
+  * Drop support for Python 3.4
+  * Add support for Python 3.7, 3.8
+
 2.0.1 (2018-02-14)
   * Fix a bug where asynchronously firing a task (the default) would
     raise an exception when run via Celery.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -r ../tests/requirements.txt
 
-Sphinx==1.8.5
-sphinx-rtd-theme==0.4.3
-Django<2.2
+Sphinx
+sphinx-rtd-theme
+Django<3.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,6 @@
 # Testing and development requirements
 -r tests/requirements.txt
-Django<2.2
+Django<3.1
 check-manifest
 coverage
 flake8

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
@@ -65,6 +66,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Communications :: Email',
         'Topic :: Software Development :: Libraries :: Python Modules'],
 )

--- a/tests/requirements-latest.txt
+++ b/tests/requirements-latest.txt
@@ -1,2 +1,0 @@
-# Latest versions of requirements
-celery

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
-# Requirements for Django 1.8
-celery==4.1.0
+# Latest versions of requirements
+celery

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ envlist =
     docs,
     flake8,
     py{27,34,35,36}-1.11
-    py{35,36,37}-{2.0,2.1,2.2,master}
+    py{35,36,37}-{2.0,2.1,master}
+    py{35,36,37,38}-2.2
+    py{36,37,38}-{3.0,master}
 
 [testenv]
 passenv = TRAVIS TRAVIS_*
@@ -15,6 +17,7 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 usedevelop = true
 pip_pre = true
 commands =
@@ -25,7 +28,8 @@ deps =
     1.11: Django>=1.11,<2.0
     2.0: Django>=2.0,<2.1
     2.1: Django>=2.1,<2.2
-    2.2: Django>=2.2a1,<2.3
+    2.2: Django>=2.2,<2.3
+    3.0: Django>=3.0,<3.1
     master: https://github.com/django/django/archive/master.tar.gz
     -r{toxinidir}/tests/requirements.txt
 whitelist_externals = make
@@ -39,5 +43,5 @@ commands = make docs
 basepython = python2.7
 deps =
     flake8
-    Django<2.2
+    Django<3.1
 commands = make lint

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters = true
 envlist =
     docs,
     flake8,
-    py{27,34,35,36}-1.11
+    py{27,35,36}-1.11
     py{35,36,37}-{2.0,2.1,master}
     py{35,36,37,38}-2.2
     py{36,37,38}-{3.0,master}
@@ -13,7 +13,6 @@ envlist =
 passenv = TRAVIS TRAVIS_*
 basepython =
     py27: python2.7
-    py34: python3.4
     py35: python3.5
     py36: python3.6
     py37: python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -27,8 +27,7 @@ deps =
     2.1: Django>=2.1,<2.2
     2.2: Django>=2.2a1,<2.3
     master: https://github.com/django/django/archive/master.tar.gz
-    {1.11,2.0,2.1,2.2}: -r{toxinidir}/tests/requirements.txt
-    master: -r{toxinidir}/tests/requirements-latest.txt
+    -r{toxinidir}/tests/requirements.txt
 whitelist_externals = make
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -34,12 +34,12 @@ deps =
 whitelist_externals = make
 
 [testenv:docs]
-basepython = python2.7
+basepython = python3.6
 deps = -r{toxinidir}/docs/requirements.txt
 commands = make docs
 
 [testenv:flake8]
-basepython = python2.7
+basepython = python3.6
 deps =
     flake8
     Django<3.1


### PR DESCRIPTION
Update the test matrix to test released Django 2.2, Django 3.0, and Python 3.8.

Also, unpin the tested version of Celery, since the comment suggests this was for Django 1.8 support. However, this caused the Python 3.4 test to fail. It appears upstream Celery no longer supports Python 3.4, and it is at end-of-life, so we are dropping it as well.